### PR TITLE
New final_date option for ./add_round

### DIFF
--- a/GoatLib.pm
+++ b/GoatLib.pm
@@ -10,7 +10,7 @@ use Date::Language;
 use DateTime::TimeZone;
 
 @ISA=qw(Exporter);
-@EXPORT=qw( stone_to_level level_to_stones map_game download_echelle parse_datestr);
+@EXPORT=qw( stone_to_level level_to_stones download_echelle parse_datestr);
 
 =head2 fixup_frenchisms
 

--- a/GoatLib.pm
+++ b/GoatLib.pm
@@ -1,9 +1,73 @@
 package GoatLib;
 
 use locale;
+use Pod::Usage;
+
 use Exporter;
+use Time::ParseDate;  # This is in Debian's libtime-modules-perl package
+use Date::Parse;
+use Date::Language;
+use DateTime::TimeZone;
+
 @ISA=qw(Exporter);
-@EXPORT=qw( stone_to_level level_to_stones map_game download_echelle);
+@EXPORT=qw( stone_to_level level_to_stones map_game download_echelle parse_datestr);
+
+=head2 fixup_frenchisms
+
+Fix up accents in dates, so sloppy French writers can get
+away with 'fev' instead of 'fév' etc.
+
+Also change '18h32' to '18:32'
+
+Also change "01/02/2016" to "02/01/2016", which may be
+wrong, but there is no better way. DateTime parses US way,
+the French do dd/mm/yyyy.
+
+=cut
+sub fixup_frenchisms {
+    my %fixups = (
+        'fevrier'  => 'février',
+        'aout'     => 'août',
+        'decembre' => 'décembre',
+    );
+    my ($date) = @_;
+
+    foreach my $k (keys %fixups) {
+        my $v = $fixups{$k};
+        $date =~ s/$k/$v/; #  Substitute whole words
+
+        $k = substr $k, 0, 3;
+        $v = substr $v, 0, 3;
+        $date =~ s/$k/$v/; # Substitute 3-letter abbreviations
+    }
+    $date =~ s/(\d\d)h(\d\d)/$1:$2/;
+
+    # Swap month and day if date in xx/yy/zz format
+    my ($d, $m, $rest) = split /\//, $date;
+    $date = "$m/$d/$rest" if (defined $m and defined $rest);
+
+    return $date;
+}
+
+# get date as string, and return a date
+#
+sub parse_datestr {
+    my ($date_str) = @_;
+
+    $date_str = Encode::decode("utf8", $date_str);
+
+    my $lang = Date::Language->new('French');
+    eval {  # str2time and others die on illegal dates: we really don't want that.
+        $date_str = fixup_frenchisms $date_str;
+        $date = $lang->str2time($date_str);
+        # Compute date in UTC using timezone in configuration
+        my $tz = DateTime::TimeZone->new(name => $TIMEZONE);
+        my $dt = DateTime->from_epoch(epoch => $date);
+        $date -= $tz->offset_for_datetime($dt);
+        #print "$date\n";
+    };
+    return $date;
+}
 
 
 # Renvoie une valeur numérique correspondant à un niveau en

--- a/add_round
+++ b/add_round
@@ -80,7 +80,7 @@ my $round = Round->new($round_num);
 # make date or get from opt
 my $final_date;
 if (defined $param_final_date) {
-    $final_date = parse_datestr();
+    $final_date = parse_datestr($param_final_date);
     die "Wrong date format $param_final_date." unless defined $final_date;
 } else {
     $final_date = time + 30 * 24 * 3600; # one month in the future

--- a/add_round
+++ b/add_round
@@ -55,6 +55,7 @@ BEGIN {
 use Tournament;
 use Getopt::Long;
 use Pod::Usage;
+use GoatLib;
 
 
 # Interpret command line
@@ -76,13 +77,16 @@ print "Creating round $round_num\n";
 my $round = Round->new($round_num);
 
 # make date or get from opt
+my $finale_date;
 if (defined $param_final_date) {
-    die "--date not implemented\n";
+    $final_date = parse_datestr();
+    die "Wrong date format $param_final_date." unless defined $final_date;
 } else {
-    $param_final_date = my_time() + 30 * 24 * 3600; # one month in the future
+    $final_date = my_time() + 30 * 24 * 3600; # one month in the future
 }
 
 
+$round->final_date($final_date);
 $Tournament->add_round($round_num, $round);
 $Tournament->save($param_file);
 

--- a/add_round
+++ b/add_round
@@ -52,6 +52,7 @@ BEGIN {
 
     push @INC, $ENV{GOAT_DIR};
 }
+
 use Tournament;
 use Getopt::Long;
 use Pod::Usage;

--- a/add_round
+++ b/add_round
@@ -78,7 +78,7 @@ print "Creating round $round_num\n";
 my $round = Round->new($round_num);
 
 # make date or get from opt
-my $finale_date;
+my $final_date;
 if (defined $param_final_date) {
     $final_date = parse_datestr();
     die "Wrong date format $param_final_date." unless defined $final_date;

--- a/add_round
+++ b/add_round
@@ -58,10 +58,11 @@ use Pod::Usage;
 
 
 # Interpret command line
-my ($testing, $param_file, $help);
+my ($testing, $param_file, $param_final_date, $help);
 GetOptions(
     'help' => \$help,
     'file=s' => \$param_file,
+    'date=s' => \$param_final_date,
 ) or die pod2usage();
 
 die pod2usage(-verbose=>2) if defined $help;
@@ -73,6 +74,15 @@ my $Tournament = Tournament->load($param_file);
 my $round_num = ($Tournament->round_number || 0) + 1;
 print "Creating round $round_num\n";
 my $round = Round->new($round_num);
+
+# make date or get from opt
+if (defined $param_final_date) {
+    die "--date not implemented\n";
+} else {
+    $param_final_date = my_time() + 30 * 24 * 3600; # one month in the future
+}
+
+
 $Tournament->add_round($round_num, $round);
 $Tournament->save($param_file);
 

--- a/add_round
+++ b/add_round
@@ -54,6 +54,7 @@ BEGIN {
 }
 use Tournament;
 use Getopt::Long;
+use Pod::Usage;
 
 
 # Interpret command line
@@ -62,6 +63,8 @@ GetOptions(
     'help' => \$help,
     'file=s' => \$param_file,
 ) or die pod2usage();
+
+die pod2usage(-verbose=>2) if defined $help;
 die "No tournament file specified. Use -f <file>.\n" unless defined $param_file;
 
 

--- a/add_round
+++ b/add_round
@@ -24,7 +24,7 @@ add_round -- creates a new round in a tournament
 
 =head1 SYNOPSIS
 
-add_round --file <toperm>
+add_round --file <toperm> [--date <date>]
 
 =head1 DESCRIPTION
 
@@ -32,9 +32,13 @@ I<add_round> simply creates an empty round in a tournament.
 In conjunction with I<add_game>, it can be used to import
 pairings made with another program.
 
+If the B<date> is specified, it will be displayed in
+all reminders. If not specified, one month from now is
+picked. ( just like <pair>  programm ).
+
 You would go about it as such:
 
-  add_round -f toperm
+  add_round -f toperm -d "19 juin 2017"
   add_game -f toperm --black alice@example.org --white bob@example.com
   add_game -f toperm --black jack@example.org --white jane@example.net
   [...]

--- a/add_round
+++ b/add_round
@@ -83,7 +83,7 @@ if (defined $param_final_date) {
     $final_date = parse_datestr();
     die "Wrong date format $param_final_date." unless defined $final_date;
 } else {
-    $final_date = my_time() + 30 * 24 * 3600; # one month in the future
+    $final_date = time + 30 * 24 * 3600; # one month in the future
 }
 
 

--- a/goat
+++ b/goat
@@ -29,8 +29,6 @@ use Mail::Address;
 use Games::Go::SGF;
 use open ':locale';
 
-use GoatLib;
-
 use Fcntl qw/SEEK_SET LOCK_EX LOCK_UN/;
 
 # Check we have the right environment variables to find
@@ -42,6 +40,7 @@ BEGIN {
     push @INC, $ENV{GOAT_DIR};
 }
 use GoatConfig;
+use GoatLib;
 
 use Tournament;
 use Round;

--- a/goat
+++ b/goat
@@ -24,14 +24,12 @@ use File::Copy;
 
 use Getopt::Long;
 use Pod::Usage;
-use Time::ParseDate;  # This is in Debian's libtime-modules-perl package
-use Date::Parse;
-use Date::Language;
-use DateTime::TimeZone;
 
 use Mail::Address;
 use Games::Go::SGF;
 use open ':locale';
+
+use GoatLib;
 
 use Fcntl qw/SEEK_SET LOCK_EX LOCK_UN/;
 
@@ -497,43 +495,6 @@ sub notify_not_registered {
     system("$BIN_MAIL_OUT $mail_out_opts --player-unknown '$player'");
 }
 
-=head2 fixup_frenchisms
-
-Fix up accents in dates, so sloppy French writers can get
-away with 'fev' instead of 'fév' etc.
-
-Also change '18h32' to '18:32'
-
-Also change "01/02/2016" to "02/01/2016", which may be
-wrong, but there is no better way. DateTime parses US way,
-the French do dd/mm/yyyy.
-
-=cut
-sub fixup_frenchisms {
-    my %fixups = (
-        'fevrier'  => 'février',
-        'aout'     => 'août',
-        'decembre' => 'décembre',
-    );
-    my ($date) = @_;
-
-    foreach my $k (keys %fixups) {
-        my $v = $fixups{$k};
-        $date =~ s/$k/$v/; #  Substitute whole words
-
-        $k = substr $k, 0, 3;
-        $v = substr $v, 0, 3;
-        $date =~ s/$k/$v/; # Substitute 3-letter abbreviations
-    }
-    $date =~ s/(\d\d)h(\d\d)/$1:$2/;
-
-    # Swap month and day if date in xx/yy/zz format
-    my ($d, $m, $rest) = split /\//, $date;
-    $date = "$m/$d/$rest" if (defined $m and defined $rest);
-
-    return $date;
-}
-
 
 # Process a game result
 # submitter: e-mail address of player submitting the result
@@ -584,20 +545,7 @@ if (defined $param_schedule) {
         exit; # Action has failed -- nothing more to do
     }
 
-    $date_str = Encode::decode("utf8", $date_str);
-
-    my $date;
-
-    my $lang = Date::Language->new('French');
-    eval {  # str2time and others die on illegal dates: we really don't want that.
-        $date_str = fixup_frenchisms $date_str;
-        $date = $lang->str2time($date_str);
-        # Compute date in UTC using timezone in configuration
-        my $tz = DateTime::TimeZone->new(name => $TIMEZONE);
-        my $dt = DateTime->from_epoch(epoch => $date);
-        $date -= $tz->offset_for_datetime($dt);
-        print "$date\n";
-    };
+    my $date = parse_datestr($date_str);
 
     unless (defined $date) {
         print "$local_today: notify $player that '$date_str' is invalid\n";

--- a/pair
+++ b/pair
@@ -60,6 +60,7 @@ BEGIN {
     push @INC, $ENV{GOAT_DIR};
 }
 
+use GoatLib;
 use Tournament;
 use Getopt::Long;
 

--- a/pair
+++ b/pair
@@ -224,7 +224,8 @@ print "Noir". " " x ($max_name_length - $bl) .
 
 my $round = Round->new($round_num);
 if (defined $param_final_date) {
-    die "--date not implemented\n";
+    $final_date = parse_datestr();
+    die "Wrong date format $param_final_date." unless defined $final_date;
 } else {
     $param_final_date = my_time() + 30 * 24 * 3600; # one month in the future
 }

--- a/pair
+++ b/pair
@@ -226,7 +226,7 @@ print "Noir". " " x ($max_name_length - $bl) .
 my $round = Round->new($round_num);
 my $final_date;
 if (defined $param_final_date) {
-    $final_date = parse_datestr();
+    $final_date = parse_datestr($param_final_date);
     die "Wrong date format $param_final_date." unless defined $final_date;
 } else {
     $param_final_date = my_time() + 30 * 24 * 3600; # one month in the future

--- a/pair
+++ b/pair
@@ -224,13 +224,14 @@ print "Noir". " " x ($max_name_length - $bl) .
 
 
 my $round = Round->new($round_num);
+my $final_date;
 if (defined $param_final_date) {
     $final_date = parse_datestr();
     die "Wrong date format $param_final_date." unless defined $final_date;
 } else {
     $param_final_date = my_time() + 30 * 24 * 3600; # one month in the future
 }
-$round->final_date($param_final_date);
+$round->final_date($final_date);
 $Tournament->add_round($round_num, $round);
 
 my @res = $matchmaker->pick();


### PR DESCRIPTION
    - add new option final_date to add_round.
    - thus moving parse_datestr() to GoatLib
    - also used in ./goat and ./pair
